### PR TITLE
Add basic plugin architecture

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3075,3 +3075,13 @@ LDAP_VALIDATE_CERT = PersistentConfig(
 LDAP_CIPHERS = PersistentConfig(
     "LDAP_CIPHERS", "ldap.server.ciphers", os.environ.get("LDAP_CIPHERS", "ALL")
 )
+
+####################################
+# PLUGINS CONFIG
+####################################
+
+PLUGINS = PersistentConfig(
+    "PLUGINS",
+    "plugins",
+    {},
+)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -83,6 +83,7 @@ from open_webui.routers import (
     tools,
     users,
     utils,
+    plugins as plugins_router,
 )
 
 from open_webui.routers.retrieval import (
@@ -437,6 +438,7 @@ from open_webui.utils.plugin import install_tool_and_function_dependencies
 from open_webui.utils.oauth import OAuthManager
 from open_webui.utils.security_headers import SecurityHeadersMiddleware
 from open_webui.utils.redis import get_redis_connection
+from open_webui.plugin_manager import load_plugins
 
 from open_webui.tasks import (
     redis_task_command_listener,
@@ -1145,6 +1147,9 @@ app.include_router(
     evaluations.router, prefix="/api/v1/evaluations", tags=["evaluations"]
 )
 app.include_router(utils.router, prefix="/api/v1/utils", tags=["utils"])
+app.include_router(plugins_router.router, prefix="/api/v1/plugins", tags=["plugins"])
+
+load_plugins(app)
 
 
 try:

--- a/backend/open_webui/plugin_manager.py
+++ b/backend/open_webui/plugin_manager.py
@@ -1,0 +1,47 @@
+import importlib
+import logging
+import pkgutil
+from pathlib import Path
+from fastapi import FastAPI
+from open_webui.config import save_config
+
+log = logging.getLogger(__name__)
+
+
+def load_plugins(app: FastAPI):
+    """Discover and load plugins from the ``plugins`` package."""
+    try:
+        pkg = importlib.import_module("plugins")
+    except ModuleNotFoundError:
+        log.info("No plugins directory found")
+        app.state.loaded_plugins = []
+        return []
+
+    plugin_path = Path(pkg.__file__).parent
+    loaded = []
+
+    for _, name, _ in pkgutil.iter_modules([str(plugin_path)]):
+        module = importlib.import_module(f"plugins.{name}")
+
+        # Register router if available
+        if hasattr(module, "router"):
+            prefix = getattr(module, "PREFIX", f"/plugins/{name}")
+            app.include_router(module.router, prefix=prefix, tags=["plugins"])
+
+        # Run custom setup if defined
+        if hasattr(module, "setup"):
+            try:
+                module.setup(app)
+            except Exception as exc:
+                log.exception("Error setting up plugin %s: %s", name, exc)
+
+        # Persist default configuration
+        if hasattr(module, "default_config"):
+            cfg = app.state.config.PLUGINS
+            if name not in cfg:
+                cfg[name] = module.default_config
+                app.state.config.PLUGINS = cfg
+        loaded.append(name)
+
+    app.state.loaded_plugins = loaded
+    return loaded

--- a/backend/open_webui/routers/plugins.py
+++ b/backend/open_webui/routers/plugins.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from open_webui.utils.auth import get_admin_user, get_verified_user
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[str])
+async def list_plugins(request: Request, user=Depends(get_verified_user)):
+    """Return list of loaded plugin names."""
+    return getattr(request.app.state, "loaded_plugins", [])
+
+
+class PluginConfigForm(BaseModel):
+    config: dict
+
+
+@router.get("/{plugin}/config", response_model=dict)
+async def get_plugin_config(
+    plugin: str, request: Request, user=Depends(get_admin_user)
+):
+    return request.app.state.config.PLUGINS.get(plugin, {})
+
+
+@router.post("/{plugin}/config", response_model=dict)
+async def set_plugin_config(
+    plugin: str, form: PluginConfigForm, request: Request, user=Depends(get_admin_user)
+):
+    cfg = request.app.state.config.PLUGINS
+    cfg[plugin] = form.config
+    request.app.state.config.PLUGINS = cfg
+    return cfg[plugin]

--- a/plugins/time_plugin/__init__.py
+++ b/plugins/time_plugin/__init__.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+
+@router.get("/", response_model=dict)
+async def get_time(request: Request):
+    """Return the current server time."""
+    return {"time": datetime.utcnow().isoformat() + "Z"}
+
+
+# Default configuration for this plugin
+default_config = {"enabled": True}
+
+# Example setup function showing how a plugin can modify the app
+
+
+def setup(app):
+    if default_config.get("enabled"):
+
+        @app.middleware("http")
+        async def add_time_header(request: Request, call_next):
+            response = await call_next(request)
+            response.headers["X-Time-Plugin"] = "1"
+            return response


### PR DESCRIPTION
## Summary
- enable plugin architecture through new `load_plugins` helper
- expose plugin admin routes via `/api/v1/plugins`
- register plugins during startup
- store plugin configuration in persistent config
- add example `time_plugin`

## Testing
- `npm run format:backend`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c412c6d388326a6c5d1142ee1c8cf